### PR TITLE
Feature/suppress deprecation warnings

### DIFF
--- a/lib/jpegtran.rb
+++ b/lib/jpegtran.rb
@@ -45,12 +45,12 @@ module Jpegtran
       end
     end
 
-    # Fixnum arguments
+    # Integer arguments
     [ :rotate, :restart ].each do |arg|
-      if Fixnum === options[arg]
+      if Integer === options[arg]
         cmd << "-#{arg} #{options[arg]}"
       elsif options.include?(arg)
-        raise Error.new("Invalid value for :#{arg} option. Fixnum expected.")
+        raise Error.new("Invalid value for :#{arg} option. Integer expected.")
       end
     end
 

--- a/lib/jpegtran/version.rb
+++ b/lib/jpegtran/version.rb
@@ -1,3 +1,3 @@
 module Jpegtran
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
ruby 2.4 から Fixnum と Bignum が Integer に統合された関係で出力される deprecation warning を出力されないように修正した。